### PR TITLE
No see prune for good cap

### DIFF
--- a/src/bm/bm_search/move_gen.rs
+++ b/src/bm/bm_search/move_gen.rs
@@ -10,8 +10,8 @@ use cozy_chess::{Board, Piece, PieceMoves};
 
 const MAX_MOVES: usize = 218;
 
-#[derive(PartialEq, Eq)]
-enum Phase {
+#[derive(PartialEq, Eq, Copy, Debug, Clone, PartialOrd, Ord)]
+pub enum Phase {
     PvMove,
     GenPieceMoves,
     GenCaptures,
@@ -88,6 +88,10 @@ impl OrderedMoveGen {
             captures: ArrayVec::new(),
             bad_captures: ArrayVec::new(),
         }
+    }
+
+    pub fn phase(&self) -> Phase {
+        self.phase
     }
 
     pub fn skip_quiets(&mut self) {

--- a/src/bm/bm_search/search.rs
+++ b/src/bm/bm_search/search.rs
@@ -10,7 +10,7 @@ use crate::bm::bm_util::t_table::EntryType;
 use crate::bm::bm_util::t_table::EntryType::{Exact, LowerBound, UpperBound};
 
 use super::move_gen::{OrderedMoveGen, Phase, QSearchMoveGen};
-use super::see::compare_see;
+use super::see::{self, compare_see};
 
 pub trait SearchType {
     const NM: bool;
@@ -425,13 +425,8 @@ pub fn search<Search: SearchType>(
             && depth <= 7
             && move_gen.phase() > Phase::GoodCaptures;
 
-        if do_see_prune
-            && !compare_see(
-                pos.board(),
-                make_move,
-                (alpha - eval - see_fp(depth) + 1).raw(),
-            )
-        {
+        let see_margin = (alpha - eval - see_fp(depth) + 1).raw();
+        if do_see_prune && (see_margin > 0 || !compare_see(pos.board(), make_move, see_margin)) {
             continue;
         }
 

--- a/src/bm/bm_search/search.rs
+++ b/src/bm/bm_search/search.rs
@@ -9,7 +9,7 @@ use crate::bm::bm_util::position::Position;
 use crate::bm::bm_util::t_table::EntryType;
 use crate::bm::bm_util::t_table::EntryType::{Exact, LowerBound, UpperBound};
 
-use super::move_gen::{OrderedMoveGen, QSearchMoveGen};
+use super::move_gen::{OrderedMoveGen, Phase, QSearchMoveGen};
 use super::see::compare_see;
 
 pub trait SearchType {
@@ -419,7 +419,11 @@ pub fn search<Search: SearchType>(
         In non-PV nodes If a move evaluated by SEE isn't good enough to beat alpha - a static margin
         we assume it's safe to prune this move
         */
-        let do_see_prune = !Search::PV && non_mate_line && moves_seen > 0 && depth <= 7;
+        let do_see_prune = !Search::PV
+            && non_mate_line
+            && moves_seen > 0
+            && depth <= 7
+            && move_gen.phase() > Phase::GoodCaptures;
 
         if do_see_prune
             && !compare_see(


### PR DESCRIPTION
SEE pruning had the chance to prune every move except the first in if eval and alpha difference was large enough (~1500 for depth 8) 

This disables pruning entirely for good captures

STC:
```
ELO   | 2.64 +- 1.96 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.98 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 56976 W: 13751 L: 13318 D: 29907
```

LTC:
```
ELO   | 4.40 +- 3.47 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 17208 W: 3966 L: 3748 D: 9494
```