### PR TITLE
Only use SEE comparison

### DIFF
--- a/src/bm/bm_search/move_gen.rs
+++ b/src/bm/bm_search/move_gen.rs
@@ -1,7 +1,7 @@
 use cozy_chess::Move;
 
 use super::move_entry::MoveEntry;
-use super::see::{calculate_see, compare_see, move_value};
+use super::see::{compare_see, move_value};
 use crate::bm::bm_util::history::History;
 use crate::bm::bm_util::history::HistoryIndices;
 use crate::bm::bm_util::position::Position;
@@ -229,7 +229,7 @@ impl QSearchMoveGen {
         }
     }
 
-    pub fn next(&mut self, pos: &Position, hist: &History) -> Option<(Move, i16)> {
+    pub fn next(&mut self, pos: &Position, hist: &History) -> Option<Move> {
         if self.phase == QPhase::GenCaptures {
             self.phase = QPhase::GoodCaptures;
             let stm = pos.board().side_to_move();
@@ -245,11 +245,7 @@ impl QSearchMoveGen {
         if self.phase == QPhase::GoodCaptures {
             while let Some(index) = select_highest(&self.captures, |capture| capture.score) {
                 let capture = self.captures.swap_remove(index).mv;
-                let see = calculate_see(pos.board(), capture);
-                if see < 0 {
-                    continue;
-                }
-                return Some((capture, see));
+                return Some(capture);
             }
         }
         None

--- a/src/bm/bm_search/search.rs
+++ b/src/bm/bm_search/search.rs
@@ -661,45 +661,47 @@ pub fn q_search(
     }
 
     let mut move_gen = QSearchMoveGen::new();
-    while let Some((make_move, see)) = move_gen.next(pos, &local_context.history) {
-        let is_capture = pos
-            .board()
-            .colors(!pos.board().side_to_move())
-            .has(make_move.to);
-        if in_check || is_capture {
-            /*
-            SEE beta cutoff: (Koivisto)
-            If SEE considerably improves evaluation above beta, we can return beta early
-            */
-            if stand_pat + see - 193 >= beta {
-                return beta;
-            }
-            if stand_pat + 200 <= alpha && see <= 0 {
-                continue;
-            }
-            pos.make_move(make_move);
-            let search_score = q_search(
-                pos,
-                local_context,
-                shared_context,
-                ply + 1,
-                beta >> Next,
-                alpha >> Next,
-            );
-            let score = search_score << Next;
-            if highest_score.is_none() || score > highest_score.unwrap() {
-                highest_score = Some(score);
-                best_move = Some(make_move);
-            }
-            if score > alpha {
-                alpha = score;
-                if score >= beta {
-                    pos.unmake_move();
-                    break;
-                }
-            }
-            pos.unmake_move();
+    while let Some(make_move) = move_gen.next(pos, &local_context.history) {
+        /*
+        Prune all losing captures
+        */
+        if !compare_see(pos.board(), make_move, 0) {
+            continue;
         }
+        /*
+        Fail high if SEE puts us above beta
+        */
+        if stand_pat + 1000 >= beta
+            && compare_see(pos.board(), make_move, (beta - stand_pat + 193).raw())
+        {
+            return beta;
+        }
+        // Also prune neutral captures when static eval is low
+        if stand_pat + 200 <= alpha && !compare_see(pos.board(), make_move, 1) {
+            continue;
+        }
+        pos.make_move(make_move);
+        let search_score = q_search(
+            pos,
+            local_context,
+            shared_context,
+            ply + 1,
+            beta >> Next,
+            alpha >> Next,
+        );
+        let score = search_score << Next;
+        if highest_score.is_none() || score > highest_score.unwrap() {
+            highest_score = Some(score);
+            best_move = Some(make_move);
+        }
+        if score > alpha {
+            alpha = score;
+            if score >= beta {
+                pos.unmake_move();
+                break;
+            }
+        }
+        pos.unmake_move();
     }
     if let Some((best_move, highest_score)) = best_move.zip(highest_score) {
         let entry_type = match () {


### PR DESCRIPTION
STC test due to this being a functionally equivalent change

```
ELO   | 0.21 +- 3.12 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.97 (-2.94, 2.94) [-5.00, 0.00]
GAMES | N: 23120 W: 5625 L: 5611 D: 11884
```