### PR TITLE
Razor qs margin const

### DIFF
--- a/src/bm/bm_search/search.rs
+++ b/src/bm/bm_search/search.rs
@@ -52,8 +52,12 @@ const fn do_razor(depth: u32) -> bool {
     depth <= 4
 }
 
-const fn razor(depth: u32) -> i16 {
+const fn razor_margin(depth: u32) -> i16 {
     depth as i16 * 287
+}
+
+const fn razor_qsearch(depth: u32) -> i16 {
+    depth as i16 * 143
 }
 
 fn do_nmp<Search: SearchType>(
@@ -206,9 +210,9 @@ pub fn search<Search: SearchType>(
             return eval;
         }
 
-        let razor_margin = razor(depth);
+        let razor_margin = razor_margin(depth);
         if do_razor(depth) && eval + razor_margin <= alpha {
-            let zw = alpha - razor_margin;
+            let zw = alpha - razor_qsearch(depth);
             let q_search = q_search(pos, thread, shared_context, ply, zw, zw + 1);
             if q_search <= zw {
                 return q_search;

--- a/src/bm/bm_search/search.rs
+++ b/src/bm/bm_search/search.rs
@@ -56,8 +56,8 @@ const fn razor_margin(depth: u32) -> i16 {
     depth as i16 * 287
 }
 
-const fn razor_qsearch(depth: u32) -> i16 {
-    depth as i16 * 143
+const fn razor_qsearch() -> i16 {
+    287
 }
 
 fn do_nmp<Search: SearchType>(
@@ -212,7 +212,7 @@ pub fn search<Search: SearchType>(
 
         let razor_margin = razor_margin(depth);
         if do_razor(depth) && eval + razor_margin <= alpha {
-            let zw = alpha - razor_qsearch(depth);
+            let zw = alpha - razor_qsearch();
             let q_search = q_search(pos, thread, shared_context, ply, zw, zw + 1);
             if q_search <= zw {
                 return q_search;


### PR DESCRIPTION
Constant margin for razoring to pass after initial eval check.

STC:
```
Elo   | 2.93 +- 2.92 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
Games | N: 26114 W: 6388 L: 6168 D: 13558
Penta | [228, 3023, 6349, 3215, 242]
```
LTC:
```
Elo   | 4.87 +- 4.52 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 3.02 (-2.94, 2.94) [0.00, 5.00]
Games | N: 10488 W: 2503 L: 2356 D: 5629
Penta | [31, 1192, 2657, 1327, 37]
```