### PR TITLE
Avoid unnecessary board clone & make move

### DIFF
--- a/src/bm/bm_util/position.rs
+++ b/src/bm/bm_util/position.rs
@@ -96,6 +96,7 @@ impl Position {
 
         self.evaluator.make_move(
             &old_board,
+            &self.current,
             make_move,
             self.w_threats,
             self.b_threats,

--- a/src/bm/nnue/mod.rs
+++ b/src/bm/nnue/mod.rs
@@ -206,6 +206,7 @@ impl Nnue {
     pub fn make_move(
         &mut self,
         board: &Board,
+        new_board: &Board,
         make_move: Move,
         w_threats: BitBoard,
         b_threats: BitBoard,
@@ -219,9 +220,7 @@ impl Nnue {
         let w_king = board.king(Color::White);
         let b_king = board.king(Color::Black);
         if from_type == Piece::King {
-            let mut board_clone = board.clone();
-            board_clone.play_unchecked(make_move);
-            self.reset(&board_clone, w_threats, b_threats);
+            self.reset(&new_board, w_threats, b_threats);
             return;
         }
         for w_threat_sq in w_threats ^ old_w_threats {


### PR DESCRIPTION
Minor non-functional optimization:
STC
```
Elo   | 4.12 +- 5.48 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 3.02 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 7414 W: 1828 L: 1740 D: 3846
Penta | [67, 862, 1760, 952, 66]
```