### PR TITLE
Use LMR depth in futility pruning

### DIFF
--- a/src/bm/bm_search/search.rs
+++ b/src/bm/bm_search/search.rs
@@ -381,7 +381,7 @@ pub fn search<Search: SearchType>(
         In non-PV nodes If a move isn't good enough to beat alpha - a static margin
         we assume it's safe to prune this move
         */
-        let do_fp = !Search::PV && non_mate_line && moves_seen > 0 && !is_capture && depth <= 10;
+        let do_fp = !Search::PV && non_mate_line && moves_seen > 0 && !is_capture && depth <= 8;
 
         if do_fp && eval + fp(lmr_depth) <= alpha {
             move_gen.skip_quiets();

--- a/src/bm/bm_search/search.rs
+++ b/src/bm/bm_search/search.rs
@@ -381,10 +381,9 @@ pub fn search<Search: SearchType>(
         In non-PV nodes If a move isn't good enough to beat alpha - a static margin
         we assume it's safe to prune this move
         */
-        let do_fp =
-            !Search::PV && non_mate_line && moves_seen > 0 && !is_capture && lmr_depth <= 10;
+        let do_fp = !Search::PV && non_mate_line && moves_seen > 0 && !is_capture && depth <= 10;
 
-        if do_fp && eval + fp(depth) <= alpha {
+        if do_fp && eval + fp(lmr_depth) <= alpha {
             move_gen.skip_quiets();
             continue;
         }

--- a/src/bm/bm_search/search.rs
+++ b/src/bm/bm_search/search.rs
@@ -370,13 +370,19 @@ pub fn search<Search: SearchType>(
                 }
             }
         }
+        let mut reduction = shared_context
+            .get_lmr_lookup()
+            .get(depth as usize, moves_seen) as i16;
+
+        let lmr_depth = depth.saturating_sub(reduction as u32);
 
         let non_mate_line = highest_score.map_or(false, |s: Evaluation| !s.is_mate());
         /*
         In non-PV nodes If a move isn't good enough to beat alpha - a static margin
         we assume it's safe to prune this move
         */
-        let do_fp = !Search::PV && non_mate_line && moves_seen > 0 && !is_capture && depth <= 10;
+        let do_fp =
+            !Search::PV && non_mate_line && moves_seen > 0 && !is_capture && lmr_depth <= 10;
 
         if do_fp && eval + fp(depth) <= alpha {
             move_gen.skip_quiets();
@@ -439,9 +445,6 @@ pub fn search<Search: SearchType>(
         If the move proves to be worse than alpha, we don't have to do a
         full depth search
         */
-        let mut reduction = shared_context
-            .get_lmr_lookup()
-            .get(depth as usize, moves_seen) as i16;
 
         if moves_seen > 0 {
             /*


### PR DESCRIPTION
Reduce futility pruning depth and use LMR depth for pruning margin instead.

STC on previous main
```
Elo   | 2.75 +- 2.73 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 4.00]
Games | N: 30068 W: 7382 L: 7144 D: 15542
Penta | [241, 3493, 7355, 3677, 268]
```

LTC
```
Elo   | 3.34 +- 3.34 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 4.00]
Games | N: 18852 W: 4375 L: 4194 D: 10283
Penta | [41, 2058, 5060, 2213, 54]
```