### PR TITLE
Quad Bucket 63

### DIFF
--- a/nn/default.bin
+++ b/nn/default.bin
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:234f46e2853db585712fcb7ce3a815f89298433a506d6e27f2d175eb6b6587be
+oid sha256:d3d48148b7c64478d97afcb2348ab9372da9cf049a8ed08c0a4513f5e3adf8ff
 size 29369372

--- a/src/bm/nnue/mod.rs
+++ b/src/bm/nnue/mod.rs
@@ -347,7 +347,7 @@ impl Nnue {
         layers::sq_clipped_relu(*stm.get(), &mut incr.0);
         layers::sq_clipped_relu(*nstm.get(), &mut incr.0[MID..]);
 
-        let bucket = (piece_cnt / 4).min(7);
+        let bucket = (((63 - piece_cnt) * (32 - piece_cnt)) / 225).min(7);
         layers::scale_network_output(self.out_layer.feed_forward(&incr, bucket))
     }
 }


### PR DESCRIPTION
Use quadratic piece count bucket formula.
This causes buckets to be more granular at low piece counts.

Passed LTC:
```
Elo   | 4.54 +- 4.13 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.98 (-2.94, 2.94) [0.00, 4.00]
Games | N: 13098 W: 3249 L: 3078 D: 6771
Penta | [54, 1399, 3482, 1550, 64]
```