### PR TITLE
Negative extensions

### DIFF
--- a/src/bm/bm_search/search.rs
+++ b/src/bm/bm_search/search.rs
@@ -312,7 +312,7 @@ pub fn search<Search: SearchType>(
         };
         thread.ss[ply as usize + 1].pv_len = 0;
 
-        let mut extension = 0;
+        let mut extension: i32 = 0;
         let mut score;
 
         /*
@@ -367,6 +367,8 @@ pub fn search<Search: SearchType>(
                     our singular beta is above beta, we assume the move is good enough to beat beta
                     */
                     return s_beta;
+                } else if multi_cut && entry.score() >= beta {
+                    extension = -1;
                 }
             }
         }
@@ -468,20 +470,21 @@ pub fn search<Search: SearchType>(
             reduction = reduction.min(depth as i16 - 2).max(0);
         }
 
-        let lmr_depth = (depth as i16 - reduction) as u32;
-
         if moves_seen == 0 {
+            let depth = (depth as i32 + extension) as u32;
             let search_score = search::<Search>(
                 pos,
                 thread,
                 shared_context,
                 ply + 1,
-                depth - 1 + extension,
+                depth - 1,
                 beta >> Next,
                 alpha >> Next,
             );
             score = search_score << Next;
         } else {
+            let depth = (depth as i32 + extension) as u32;
+            let lmr_depth = (depth as i16 - reduction) as u32;
             //Reduced Search/Zero Window if no reduction
             let zw = alpha >> Next;
 
@@ -490,7 +493,7 @@ pub fn search<Search: SearchType>(
                 thread,
                 shared_context,
                 ply + 1,
-                lmr_depth - 1 + extension,
+                lmr_depth - 1,
                 zw - 1,
                 zw,
             );
@@ -506,7 +509,7 @@ pub fn search<Search: SearchType>(
                     thread,
                     shared_context,
                     ply + 1,
-                    depth - 1 + extension,
+                    depth - 1,
                     zw - 1,
                     zw,
                 );
@@ -521,7 +524,7 @@ pub fn search<Search: SearchType>(
                     thread,
                     shared_context,
                     ply + 1,
-                    depth - 1 + extension,
+                    depth - 1,
                     beta >> Next,
                     alpha >> Next,
                 );


### PR DESCRIPTION
Reduce TT move if singular search cannot prove that it is better 

Passed STC:
```
Elo   | 3.17 +- 3.07 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 4.00]
Games | N: 23484 W: 5744 L: 5530 D: 12210
Penta | [173, 2707, 5779, 2899, 184]
```

Passed LTC:
```
Elo   | 3.37 +- 3.33 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 4.00]
Games | N: 18996 W: 4405 L: 4221 D: 10370
Penta | [51, 2093, 5034, 2261, 59]
```