### PR TITLE
LTC time management tune

### DIFF
--- a/src/bm/bm_runner/time.rs
+++ b/src/bm/bm_runner/time.rs
@@ -7,7 +7,7 @@ use std::time::{Duration, Instant};
 
 use super::ab_runner::MAX_PLY;
 
-const EXPECTED_MOVES: u32 = 40;
+const EXPECTED_MOVES: u32 = 64;
 
 const TIME_DEFAULT: Duration = Duration::from_secs(0);
 const INC_DEFAULT: Duration = Duration::from_secs(0);
@@ -88,18 +88,18 @@ impl TimeManager {
         if thread != 0 || depth <= 4 {
             return;
         }
-        let mut prev_move = self.prev_move.lock().unwrap();
 
+        let mut prev_move = self.prev_move.lock().unwrap();
         let mut move_stability = self.move_stability.load(Ordering::Relaxed);
         move_stability = match Some(mv) == *prev_move {
-            true => (move_stability + 1).min(10),
+            true => (move_stability + 1).min(14),
             false => 0,
         };
         *prev_move = Some(mv);
         self.move_stability.store(move_stability, Ordering::Relaxed);
-        let move_stability_factor = (50 - move_stability) as f32 / 40.0;
-        let node_factor = (1.0 - move_nodes as f32 / nodes as f32) * 2.0 + 0.5;
-        let eval_factor = (prev_eval - eval).clamp(20, 60) as f32 / 20.0;
+        let move_stability_factor = (41 - move_stability) as f32 * 0.024;
+        let node_factor = (1.0 - move_nodes as f32 / nodes as f32) * 3.42 + 0.52;
+        let eval_factor = (prev_eval - eval).clamp(18, 20) as f32 * 0.088;
         let base_duration = self.base_duration.load(Ordering::Relaxed);
         let target_duration =
             base_duration as f32 * move_stability_factor * node_factor * eval_factor;


### PR DESCRIPTION
Tuned time management parameters with GA at LTC

Fails at STC
```
Elo   | -4.54 +- 5.03 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | -2.98 (-2.94, 2.94) [0.00, 4.00]
Games | N: 8802 W: 2060 L: 2175 D: 4567
Penta | [82, 1092, 2146, 1021, 60]
```

Passed LTC
```
Elo   | 5.24 +- 4.44 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 4.00]
Games | N: 10810 W: 2570 L: 2407 D: 5833
Penta | [38, 1194, 2762, 1389, 22]
```