### PR TITLE
Tweak aggression

### DIFF
--- a/src/bm/bm_util/position.rs
+++ b/src/bm/bm_util/position.rs
@@ -148,11 +148,11 @@ impl Position {
     pub fn aggression(&self, stm: Color, root_eval: Evaluation) -> i16 {
         let piece_cnt = self.board().occupied().len() as i16;
 
-        let clamped_eval = root_eval.raw().clamp(-100, 100);
-        match self.board().side_to_move() == stm {
-            true => piece_cnt * clamped_eval / 50,
-            false => -piece_cnt * clamped_eval / 50,
-        }
+        let clamped_eval = root_eval.raw().clamp(-200, 200);
+        (match self.board().side_to_move() == stm {
+            true => piece_cnt * clamped_eval,
+            false => -piece_cnt * clamped_eval,
+        }) / 100
     }
 
     /// Calculates NN evaluation + FRC bonus


### PR DESCRIPTION
Tweak aggression formula

Passed LTC:
```
Elo   | 3.12 +- 3.18 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 4.00]
Games | N: 20944 W: 4897 L: 4709 D: 11338
Penta | [53, 2272, 5668, 2392, 87]
```

Passed STC:
```
Elo   | 1.84 +- 1.77 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 4.00]
Games | N: 71700 W: 17662 L: 17282 D: 36756
Penta | [651, 8573, 17198, 8601, 827]
```