### PR TITLE
Prefetch in quiescence search

### DIFF
--- a/src/bm/bm_search/search.rs
+++ b/src/bm/bm_search/search.rs
@@ -689,7 +689,9 @@ pub fn q_search(
         if stand_pat + 200 <= alpha && !compare_see(pos.board(), make_move, 1) {
             continue;
         }
-        pos.make_move(make_move);
+        pos.make_move_fetch(make_move, |board| {
+            shared_context.get_t_table().prefetch(board)
+        });
         let search_score = q_search(
             pos,
             thread,


### PR DESCRIPTION
Non functional performance gainer, only tested STC.

Passed STC :
```
Elo   | 9.39 +- 6.12 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 4.00]
Games | N: 6144 W: 1608 L: 1442 D: 3094
Penta | [53, 688, 1433, 836, 62]
```