### PR TITLE
Don't count pawns for aggression

### DIFF
--- a/src/bm/bm_util/position.rs
+++ b/src/bm/bm_util/position.rs
@@ -146,12 +146,13 @@ impl Position {
     /// - Value may vary depending on position and root evaluation
     /// - Avoid storing, instead recalculate for a given position
     pub fn aggression(&self, stm: Color, root_eval: Evaluation) -> i16 {
-        let piece_cnt = self.board().occupied().len() as i16;
+        let piece_cnt = self.board().occupied().len() - self.board().pieces(Piece::Pawn).len();
+        let scale = 2 * piece_cnt as i16;
 
         let clamped_eval = root_eval.raw().clamp(-200, 200);
         (match self.board().side_to_move() == stm {
-            true => piece_cnt * clamped_eval,
-            false => -piece_cnt * clamped_eval,
+            true => scale * clamped_eval,
+            false => -scale * clamped_eval,
         }) / 100
     }
 


### PR DESCRIPTION
Use non-pawn piece count in aggression, passes STC and LTC

Passed STC:
```
Elo   | 2.33 +- 2.32 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 3.02 (-2.94, 2.94) [0.00, 4.00]
Games | N: 41814 W: 10298 L: 10017 D: 21499
Penta | [373, 4852, 10219, 5047, 416]
```
Passed LTC:
```
Elo   | 1.92 +- 2.07 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 4.00]
Games | N: 50260 W: 11873 L: 11595 D: 26792
Penta | [183, 5656, 13170, 5942, 179]
```
