### PR TITLE
Average eval and beta for RFP

### DIFF
--- a/src/bm/bm_search/search.rs
+++ b/src/bm/bm_search/search.rs
@@ -202,7 +202,7 @@ pub fn search<Search: SearchType>(
         we assume we can at least achieve beta
         */
         if do_rev_fp(depth) && eval - rev_fp(depth, improving && nstm_threats.is_empty()) >= beta {
-            return eval;
+            return (eval + beta) / 2;
         }
 
         let razor_margin = razor_margin(depth);


### PR DESCRIPTION
Passed STC:
```
Elo   | 4.52 +- 3.89 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 4.00]
Games | N: 15082 W: 3821 L: 3625 D: 7636
Penta | [147, 1756, 3564, 1902, 172]
```
Passed LTC:
```
Elo   | 3.06 +- 3.09 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 4.00]
Games | N: 22264 W: 5209 L: 5013 D: 12042
Penta | [66, 2499, 5829, 2649, 89]
```