### PR TITLE
Cut node

### DIFF
--- a/src/bm/bm_runner/ab_runner.rs
+++ b/src/bm/bm_runner/ab_runner.rs
@@ -284,6 +284,7 @@ impl AbRunner {
                         depth,
                         alpha,
                         beta,
+                        false,
                     );
                     nodes = local_context.nodes();
                     if depth > 1 && local_context.abort {

--- a/src/bm/bm_search/search.rs
+++ b/src/bm/bm_search/search.rs
@@ -263,7 +263,7 @@ pub fn search<Search: SearchType>(
                         nmp_depth,
                         alpha,
                         beta,
-                        !cut_node,
+                        false,
                     );
                     verified = verification >= beta;
                 }
@@ -499,7 +499,7 @@ pub fn search<Search: SearchType>(
                 depth - 1,
                 beta >> Next,
                 alpha >> Next,
-                !cut_node,
+                false,
             );
             score = search_score << Next;
         } else {

--- a/src/bm/bm_search/search.rs
+++ b/src/bm/bm_search/search.rs
@@ -111,6 +111,7 @@ pub fn search<Search: SearchType>(
     mut depth: u32,
     mut alpha: Evaluation,
     beta: Evaluation,
+    cut_node: bool,
 ) -> Evaluation {
     thread.ss[ply as usize].pv_len = 0;
 
@@ -239,8 +240,16 @@ pub fn search<Search: SearchType>(
 
             let nmp_depth = nmp_depth(depth, eval.raw(), beta.raw());
             let zw = beta >> Next;
-            let search_score =
-                search::<NoNm>(pos, thread, shared_context, ply + 1, nmp_depth, zw, zw + 1);
+            let search_score = search::<NoNm>(
+                pos,
+                thread,
+                shared_context,
+                ply + 1,
+                nmp_depth,
+                zw,
+                zw + 1,
+                !cut_node,
+            );
             pos.unmake_move();
             let score = search_score << Next;
             if score >= beta {
@@ -254,6 +263,7 @@ pub fn search<Search: SearchType>(
                         nmp_depth,
                         alpha,
                         beta,
+                        !cut_node,
                     );
                     verified = verification >= beta;
                 }
@@ -345,6 +355,7 @@ pub fn search<Search: SearchType>(
                         depth / 2 - 1,
                         s_beta - 1,
                         s_beta,
+                        cut_node,
                     ),
                     false => eval,
                 };
@@ -472,6 +483,9 @@ pub fn search<Search: SearchType>(
             if killers.contains(make_move) {
                 reduction -= 1;
             }
+            if cut_node {
+                reduction += 1;
+            }
             reduction = reduction.min(depth as i16 - 2).max(0);
         }
 
@@ -485,6 +499,7 @@ pub fn search<Search: SearchType>(
                 depth - 1,
                 beta >> Next,
                 alpha >> Next,
+                !cut_node,
             );
             score = search_score << Next;
         } else {
@@ -501,6 +516,7 @@ pub fn search<Search: SearchType>(
                 lmr_depth - 1,
                 zw - 1,
                 zw,
+                true,
             );
             score = lmr_score << Next;
 
@@ -517,6 +533,7 @@ pub fn search<Search: SearchType>(
                     depth - 1,
                     zw - 1,
                     zw,
+                    !cut_node,
                 );
                 score = zw_score << Next;
             }
@@ -532,6 +549,7 @@ pub fn search<Search: SearchType>(
                     depth - 1,
                     beta >> Next,
                     alpha >> Next,
+                    false,
                 );
                 score = search_score << Next;
             }


### PR DESCRIPTION
Do more LMR in expected cut nodes

passed STC:
```
Elo   | 2.35 +- 2.34 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 4.00]
Games | N: 41578 W: 10371 L: 10090 D: 21117
Penta | [418, 4830, 10058, 5019, 464]
```

passed LTC:
```
Elo   | 1.68 +- 1.76 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 4.00]
Games | N: 68328 W: 15885 L: 15555 D: 36888
Penta | [241, 7698, 17945, 8050, 230]
```