### PR TITLE
Four ply cont hist

### DIFF
--- a/src/bm/bm_search/move_gen.rs
+++ b/src/bm/bm_search/move_gen.rs
@@ -191,7 +191,13 @@ impl OrderedMoveGen {
                             let followup_move_hist = hist
                                 .get_followup_move(pos, hist_indices, mv)
                                 .unwrap_or_default();
-                            quiet_hist + counter_move_hist + followup_move_hist
+                            let followup_move_hist_2 = hist
+                                .get_followup_move_2(pos, hist_indices, mv)
+                                .unwrap_or_default();
+                            quiet_hist
+                                + counter_move_hist
+                                + followup_move_hist
+                                + followup_move_hist_2
                         }
                     };
                     self.quiets.push(ScoredMove::new(mv, score));

--- a/src/bm/bm_search/search.rs
+++ b/src/bm/bm_search/search.rs
@@ -284,14 +284,14 @@ pub fn search<Search: SearchType>(
 
     let mut highest_score = None;
 
-    let prev_move = match ply > 1 {
-        true => thread.ss[ply as usize - 2].move_played,
+    let prev_move = |prev: u32| match ply >= prev {
+        true => thread.ss[(ply - prev) as usize].move_played,
         false => None,
     };
-    let opp_move = match ply != 0 {
-        true => thread.ss[ply as usize - 1].move_played,
-        false => None,
-    };
+
+    let cont_1 = prev_move(1);
+    let cont_2 = prev_move(2);
+    let cont_4 = prev_move(4);
 
     let killers = thread.killer_moves[ply as usize];
     let mut move_gen = OrderedMoveGen::new(pos.board(), best_move, killers);
@@ -302,7 +302,7 @@ pub fn search<Search: SearchType>(
     let mut quiets = ArrayVec::<Move, 64>::new();
     let mut captures = ArrayVec::<Move, 64>::new();
 
-    let hist_indices = HistoryIndices::new(opp_move, prev_move);
+    let hist_indices = HistoryIndices::new(cont_1, cont_2, cont_4);
     while let Some(make_move) = move_gen.next(pos, &thread.history, &hist_indices) {
         let move_nodes = thread.nodes();
         if Some(make_move) == skip_move {


### PR DESCRIPTION
Four ply continuation history 

STC:
```
Elo   | 2.21 +- 2.20 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 4.00]
Games | N: 46800 W: 11652 L: 11354 D: 23794
Penta | [471, 5457, 11263, 5721, 488]
```
LTC:
```
Elo   | 1.54 +- 1.57 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 4.00]
Games | N: 86222 W: 20051 L: 19669 D: 46502
Penta | [294, 9704, 22742, 10068, 303]
```