### PR TITLE
Cut node negative extensions

### DIFF
--- a/src/bm/bm_search/search.rs
+++ b/src/bm/bm_search/search.rs
@@ -386,6 +386,8 @@ pub fn search<Search: SearchType>(
                     return s_beta;
                 } else if multi_cut && entry.score >= beta {
                     extension = -2;
+                } else if multi_cut && cut_node {
+                    extension = -1;
                 }
             }
         }

--- a/src/bm/bm_search/search.rs
+++ b/src/bm/bm_search/search.rs
@@ -387,7 +387,7 @@ pub fn search<Search: SearchType>(
                 } else if multi_cut && entry.score >= beta {
                     extension = -2;
                 } else if multi_cut && cut_node {
-                    extension = -1;
+                    extension = -2;
                 }
             }
         }


### PR DESCRIPTION
Negative extend if a singular move fails and the node is a cut node

passed STC:
```
Elo   | 3.05 +- 2.95 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 4.00]
Games | N: 26212 W: 6561 L: 6331 D: 13320
Penta | [284, 2943, 6405, 3207, 267]
```

passed LTC:
```
Elo   | 2.00 +- 2.15 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.98 (-2.94, 2.94) [0.00, 4.00]
Games | N: 46598 W: 10991 L: 10723 D: 24884
Penta | [179, 5176, 12312, 5462, 170]
```