### PR TITLE
Do IIR for TT entries that are significantly lower in depth

### DIFF
--- a/src/bm/bm_search/search.rs
+++ b/src/bm/bm_search/search.rs
@@ -274,7 +274,7 @@ pub fn search<Search: SearchType>(
         }
     }
 
-    if tt_entry.is_none() {
+    if tt_entry.map_or(true, |entry| entry.depth + 4 < depth) {
         depth -= iir(depth)
     }
 


### PR DESCRIPTION

STC:
```
Elo   | 2.07 +- 2.05 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 4.00]
Games | N: 53770 W: 13282 L: 12962 D: 27526
Penta | [516, 6304, 12984, 6506, 575]
```
LTC:
```
Elo   | 2.59 +- 2.73 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 4.00]
Games | N: 28418 W: 6633 L: 6421 D: 15364
Penta | [86, 3165, 7501, 3365, 92]
```
