### PR TITLE
32 bit TT key

### DIFF
--- a/src/bm/bm_runner/ab_runner.rs
+++ b/src/bm/bm_runner/ab_runner.rs
@@ -383,7 +383,7 @@ impl AbRunner {
             },
             shared_context: SharedContext {
                 time_manager,
-                t_table: Arc::new(TranspositionTable::new(2_usize.pow(20))),
+                t_table: Arc::new(TranspositionTable::new(16 * 1024 * 1024 / 12)),
                 lmr_lookup: Arc::new(LookUp2d::new(|depth, mv| {
                     if depth == 0 || mv == 0 {
                         0
@@ -466,8 +466,8 @@ impl AbRunner {
     }
 
     pub fn hash(&mut self, hash_mb: usize) {
-        let entry_count = hash_mb * 65536;
-        self.shared_context.t_table = Arc::new(TranspositionTable::new(entry_count));
+        let entry_count = (hash_mb as u64) * 1024 * 1024 / 12;
+        self.shared_context.t_table = Arc::new(TranspositionTable::new(entry_count as usize));
     }
 
     pub fn set_threads(&mut self, threads: u8) {

--- a/src/bm/bm_runner/ab_runner.rs
+++ b/src/bm/bm_runner/ab_runner.rs
@@ -466,7 +466,7 @@ impl AbRunner {
     }
 
     pub fn hash(&mut self, hash_mb: usize) {
-        let entry_count = (hash_mb as u64) * 1024 * 1024 / 12;
+        let entry_count = hash_mb as u64 * 1024 * 1024 / 12;
         self.shared_context.t_table = Arc::new(TranspositionTable::new(entry_count as usize));
     }
 


### PR DESCRIPTION
- Remove XOR Trick
- Use 32 bit TT key
- Store entry as 3 32 bit atomics 

LTC Regression:
```
Elo   | 0.40 +- 2.58 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.96 (-2.94, 2.94) [-4.00, 0.00]
Games | N: 31996 W: 7377 L: 7340 D: 17279
Penta | [100, 3651, 8464, 3678, 105]
```

LTC Low Hash:
```
Elo   | 3.23 +- 3.22 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=8MB
LLR   | 2.98 (-2.94, 2.94) [0.00, 4.00]
Games | N: 20574 W: 4841 L: 4650 D: 11083
Penta | [63, 2278, 5430, 2437, 79]
```

STC Low Hash:
```
Elo   | 2.97 +- 2.87 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=2MB
LLR   | 2.98 (-2.94, 2.94) [0.00, 4.00]
Games | N: 27340 W: 6774 L: 6540 D: 14026
Penta | [233, 3237, 6534, 3395, 271]
```