### PR TITLE
Make TT more collision resistant by verifying best move legality

### DIFF
--- a/src/bm/bm_search/move_gen.rs
+++ b/src/bm/bm_search/move_gen.rs
@@ -6,7 +6,7 @@ use crate::bm::bm_util::history::History;
 use crate::bm::bm_util::history::HistoryIndices;
 use crate::bm::bm_util::position::Position;
 use arrayvec::ArrayVec;
-use cozy_chess::{Board, Piece, PieceMoves};
+use cozy_chess::{Piece, PieceMoves};
 
 const MAX_MOVES: usize = 218;
 
@@ -68,10 +68,12 @@ fn select_highest(array: &[ScoredMove]) -> Option<usize> {
 }
 
 impl OrderedMoveGen {
-    pub fn new(board: &Board, pv_move: Option<Move>, killers: MoveEntry) -> Self {
+    /// Expects legal PV move
+    /// Killers are verified for legality in [next](OrderedMoveGen::next)
+    pub fn new(pv_move: Option<Move>, killers: MoveEntry) -> Self {
         Self {
             phase: Phase::PvMove,
-            pv_move: pv_move.filter(|&mv| board.is_legal(mv)),
+            pv_move,
             killers,
             killer_index: 0,
             piece_moves: ArrayVec::new(),

--- a/src/bm/bm_search/search.rs
+++ b/src/bm/bm_search/search.rs
@@ -134,7 +134,7 @@ pub fn search<Search: SearchType>(
     }
 
     let skip_move = thread.ss[ply as usize].skip_move;
-    let tt_entry = match skip_move {
+    let mut tt_entry = match skip_move {
         Some(_) => None,
         None => shared_context.get_t_table().get(pos.board()),
     };
@@ -158,6 +158,9 @@ pub fn search<Search: SearchType>(
             .is_legal(entry.table_move)
             .then_some(entry.table_move);
         thread.tt_hits += 1;
+        if best_move.is_none() {
+            tt_entry = None;
+        }
         if !Search::PV && entry.depth >= depth && best_move.is_some() {
             let score = entry.score;
             match entry.bounds {

--- a/src/bm/bm_search/search.rs
+++ b/src/bm/bm_search/search.rs
@@ -153,9 +153,12 @@ pub fn search<Search: SearchType>(
     to help with move ordering
     */
     if let Some(entry) = tt_entry {
+        best_move = pos
+            .board()
+            .is_legal(entry.table_move)
+            .then_some(entry.table_move);
         thread.tt_hits += 1;
-        best_move = Some(entry.table_move);
-        if !Search::PV && entry.depth >= depth {
+        if !Search::PV && entry.depth >= depth && best_move.is_some() {
             let score = entry.score;
             match entry.bounds {
                 Bounds::Exact => {
@@ -294,7 +297,7 @@ pub fn search<Search: SearchType>(
     let cont_4 = prev_move(4);
 
     let killers = thread.killer_moves[ply as usize];
-    let mut move_gen = OrderedMoveGen::new(pos.board(), best_move, killers);
+    let mut move_gen = OrderedMoveGen::new(best_move, killers);
 
     let mut moves_seen = 0;
     let mut move_exists = false;


### PR DESCRIPTION
No functional change other than the rare case a collision would occur. Only STC tested as performance is the only concern here.

STC:
```
Elo   | -0.15 +- 2.07 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 3.01 (-2.94, 2.94) [-4.00, 0.00]
Games | N: 52494 W: 12774 L: 12797 D: 26923
Penta | [521, 6171, 12864, 6192, 499]
```