### PR TITLE
LMR Depth History Adjust & Eval Extension Tweak & Good Capture History

### DIFF
--- a/src/bm/bm_search/search.rs
+++ b/src/bm/bm_search/search.rs
@@ -429,11 +429,16 @@ pub fn search<Search: SearchType>(
             continue;
         }
 
+        let good_capture = move_gen.phase() <= Phase::GoodCaptures;
         /*
         In low depth, non-PV nodes, we assume it's safe to prune a move
         if it has very low history
         */
-        let do_hp = !Search::PV && non_mate_line && moves_seen > 0 && depth <= 6 && eval <= alpha;
+        let do_hp = !Search::PV
+            && non_mate_line
+            && moves_seen > 0
+            && depth <= 6
+            && (!good_capture || eval <= alpha);
 
         if do_hp && (h_score as i32) < hp(depth) {
             continue;
@@ -448,7 +453,7 @@ pub fn search<Search: SearchType>(
             && moves_seen > 0
             && depth <= 6
             && !alpha.is_mate()
-            && move_gen.phase() > Phase::GoodCaptures;
+            && !good_capture;
 
         if do_see_prune {
             let see_margin = (alpha - eval - see_fp(depth) + 1).raw();


### PR DESCRIPTION
Combine 3 patches that failed STC yellow

STC: 
```
Elo   | 1.94 +- 1.92 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 4.00]
Games | N: 60784 W: 14914 L: 14574 D: 31296
Penta | [556, 7137, 14705, 7399, 595]
```

LTC: 
```
Elo   | 3.35 +- 3.32 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 4.00]
Games | N: 19082 W: 4418 L: 4234 D: 10430
Penta | [47, 2115, 5049, 2267, 63]
```