### PR TITLE
Fix quitting search at depth 1 when low on time

### DIFF
--- a/src/bm/bm_runner/time.rs
+++ b/src/bm/bm_runner/time.rs
@@ -187,7 +187,7 @@ impl TimeManager {
                 0
             };
             self.base_duration.store(default, Ordering::SeqCst);
-            self.target_duration.store(default * 4, Ordering::SeqCst);
+            self.target_duration.store(max_time, Ordering::SeqCst);
             self.max_duration.store(max_time, Ordering::SeqCst);
         };
     }

--- a/src/bm/bm_runner/time.rs
+++ b/src/bm/bm_runner/time.rs
@@ -187,7 +187,7 @@ impl TimeManager {
                 0
             };
             self.base_duration.store(default, Ordering::SeqCst);
-            self.target_duration.store(default, Ordering::SeqCst);
+            self.target_duration.store(default * 4, Ordering::SeqCst);
             self.max_duration.store(max_time, Ordering::SeqCst);
         };
     }


### PR DESCRIPTION
Set initial search time to max time as time management only takes effect at depth 4.

STC:
```
Elo   | 1.92 +- 3.69 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.98 (-2.94, 2.94) [-4.00, 0.00]
Games | N: 16606 W: 4112 L: 4020 D: 8474
Penta | [144, 1992, 3962, 2038, 167]
```

LTC: 
```
Elo   | 1.39 +- 3.35 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.97 (-2.94, 2.94) [-4.00, 0.00]
Games | N: 18680 W: 4265 L: 4190 D: 10225
Penta | [45, 2099, 4991, 2146, 59]
```