### PR TITLE
Remove depth guard from TT NMP and also allow the use of exact bounds

### DIFF
--- a/src/bm/bm_search/search.rs
+++ b/src/bm/bm_search/search.rs
@@ -230,7 +230,7 @@ pub fn search<Search: SearchType>(
         move ordering for the next ply
         */
         let tt_skip_nmp = tt_entry.map_or(false, |entry| {
-            entry.score <= alpha && entry.bounds == Bounds::UpperBound
+            entry.score <= alpha && entry.bounds != Bounds::LowerBound
         });
         if !tt_skip_nmp
             && do_nmp::<Search>(

--- a/src/bm/bm_search/search.rs
+++ b/src/bm/bm_search/search.rs
@@ -230,7 +230,7 @@ pub fn search<Search: SearchType>(
         move ordering for the next ply
         */
         let tt_skip_nmp = tt_entry.map_or(false, |entry| {
-            entry.depth + 2 >= depth && entry.score <= alpha && entry.bounds == Bounds::UpperBound
+            entry.score <= alpha && entry.bounds == Bounds::UpperBound
         });
         if !tt_skip_nmp
             && do_nmp::<Search>(


### PR DESCRIPTION
Usage of exact bounds is logically more sound and the depth guard serves practically no purpose.

Passed STC Simplification:
```
Elo   | 2.48 +- 4.02 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [-4.00, 0.00]
Games | N: 13884 W: 3415 L: 3316 D: 7153
Penta | [136, 1599, 3360, 1724, 123]
```

Passed LTC Simplification:
```
Elo   | 2.29 +- 3.93 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.95 (-2.94, 2.94) [-4.00, 0.00]
Games | N: 13490 W: 3085 L: 2996 D: 7409
Penta | [38, 1479, 3620, 1572, 36]
```