### PR TITLE
Change replacement scheme formula to have more precision

### DIFF
--- a/src/bm/bm_util/t_table.rs
+++ b/src/bm/bm_util/t_table.rs
@@ -270,7 +270,7 @@ impl TranspositionTable {
         let new_depth = new.depth + extra_depth(new);
         let prev_depth = prev.depth + extra_depth(prev);
 
-        new_depth.saturating_add(self.age_of(prev) as u32 / 2) >= prev_depth / 2
+        new_depth * 2 + self.age_of(prev) as u32 + 1 >= prev_depth
     }
 
     pub fn clean(&self) {


### PR DESCRIPTION
Precision is lost during integer division of depth and age, this patch fixes it.

STC Simplification:
``` 
Elo   | 1.78 +- 3.59 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.99 (-2.94, 2.94) [-4.00, 0.00]
Games | N: 17392 W: 4250 L: 4161 D: 8981
Penta | [154, 2012, 4304, 2043, 183]
```
LTC Simplification (Rebased):
```
Elo   | 1.30 +- 3.28 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.96 (-2.94, 2.94) [-4.00, 0.00]
Games | N: 19448 W: 4443 L: 4370 D: 10635
Penta | [46, 2228, 5117, 2273, 60]
```