### PR TITLE
Adjust NMP eval using TT

### DIFF
--- a/src/bm/bm_search/search.rs
+++ b/src/bm/bm_search/search.rs
@@ -229,22 +229,22 @@ pub fn search<Search: SearchType>(
         This is seen as the major threat in the current position and can be used in
         move ordering for the next ply
         */
-        let tt_skip_nmp = tt_entry.map_or(false, |entry| {
-            entry.score <= alpha && entry.bounds != Bounds::LowerBound
+        let nmp_eval = tt_entry.map_or(eval, |entry| match entry.bounds {
+            Bounds::LowerBound => entry.score.max(eval),
+            Bounds::Exact => entry.score,
+            Bounds::UpperBound => entry.score.min(eval),
         });
-        if !tt_skip_nmp
-            && do_nmp::<Search>(
-                pos.board(),
-                depth,
-                eval.raw(),
-                beta.raw(),
-                !nstm_threats.is_empty(),
-            )
-            && pos.null_move()
+        if do_nmp::<Search>(
+            pos.board(),
+            depth,
+            nmp_eval.raw(),
+            beta.raw(),
+            !nstm_threats.is_empty(),
+        ) && pos.null_move()
         {
             thread.ss[ply as usize].move_played = None;
 
-            let nmp_depth = nmp_depth(depth, eval.raw(), beta.raw());
+            let nmp_depth = nmp_depth(depth, nmp_eval.raw(), beta.raw());
             let zw = beta >> Next;
             let search_score = search::<NoNm>(
                 pos,


### PR DESCRIPTION
Adjust NMP eval based on TT

Passed LTC:
```
Elo   | 2.77 +- 2.88 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 4.00]
Games | N: 25462 W: 5904 L: 5701 D: 13857
Penta | [65, 2846, 6723, 3015, 82]
```
Passed STC:
```
Elo   | 1.72 +- 1.65 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 4.00]
Games | N: 82470 W: 20195 L: 19786 D: 42489
Penta | [740, 9674, 20084, 9911, 826]
```