### PR TITLE
TT eval cache

### DIFF
--- a/src/bm/bm_runner/ab_runner.rs
+++ b/src/bm/bm_runner/ab_runner.rs
@@ -92,6 +92,7 @@ impl MoveData {
 #[derive(Debug, Clone)]
 pub struct SearchStack {
     pub eval: Evaluation,
+    pub aggr: i16,
     pub skip_move: Option<Move>,
     pub move_played: Option<MoveData>,
     pub pv: [Option<Move>; MAX_PLY as usize + 1],
@@ -99,6 +100,10 @@ pub struct SearchStack {
 }
 
 impl SearchStack {
+    pub fn full_eval(&self) -> Evaluation {
+        self.eval + self.aggr
+    }
+
     pub fn update_pv(&mut self, best_move: Move, child_pv: &[Option<Move>]) {
         self.pv[0] = Some(best_move);
         for (pv, &child) in self.pv[1..].iter_mut().zip(child_pv) {
@@ -412,6 +417,7 @@ impl AbRunner {
                         move_played: None,
                         pv: [None; MAX_PLY as usize + 1],
                         pv_len: 0,
+                        aggr: 0
                     };
                     MAX_PLY as usize + 1
                 ],

--- a/src/bm/bm_util/position.rs
+++ b/src/bm/bm_util/position.rs
@@ -128,7 +128,7 @@ impl Position {
             self.last_eval += 1;
             let Some(last_mv) = self.moves[idx] else {
                 self.evaluator.null_move();
-                return;
+                continue;
             };
             let (old_w_threats, old_b_threats) = self.threats[idx];
             let (w_threats, b_threats) = self.threats[idx + 1];


### PR DESCRIPTION
Store evaluations in TT for reuse. Performance improvement, STC only.

```
Elo   | 3.36 +- 3.18 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 4.00]
Games | N: 22122 W: 5452 L: 5238 D: 11432
Penta | [173, 2604, 5333, 2738, 213]
```