### PR TITLE
Low depth double extensions

### DIFF
--- a/src/bm/bm_search/search.rs
+++ b/src/bm/bm_search/search.rs
@@ -380,6 +380,9 @@ pub fn search<Search: SearchType>(
                             extension += 1;
                         }
                     }
+                    if !multi_cut && eval + 100 <= alpha {
+                        extension += 1;
+                    }
                     thread.history.update_history(
                         pos,
                         &hist_indices,

--- a/src/bm/bm_search/search.rs
+++ b/src/bm/bm_search/search.rs
@@ -380,7 +380,7 @@ pub fn search<Search: SearchType>(
                             extension += 1;
                         }
                     }
-                    if !multi_cut && eval + 100 <= alpha {
+                    if !Search::PV && !multi_cut && eval + 100 <= alpha {
                         extension += 1;
                     }
                     thread.history.update_history(


### PR DESCRIPTION
Low depth singular double extend if static evaluation is significantly lower than alpha.  


Passed STC:
```
Elo   | 2.53 +- 2.02 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.98 (-2.94, 2.94) [0.00, 4.00]
Games | N: 36018 W: 9003 L: 8741 D: 18274
Penta | [313, 4281, 8588, 4485, 342]
```

Passed LTC:
```
Elo   | 1.24 +- 0.98 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 3.00]
Games | N: 119670 W: 27574 L: 27147 D: 64949
Penta | [303, 13366, 32068, 13797, 301]
```
