### PR TITLE
Less LMR for move that increases threats

### DIFF
--- a/src/bm/bm_search/search.rs
+++ b/src/bm/bm_search/search.rs
@@ -205,7 +205,7 @@ pub fn search<Search: SearchType>(
         None => false,
     };
 
-    let (_, nstm_threats) = pos.threats();
+    let (stm_threats, nstm_threats) = pos.threats();
     if !Search::PV && !in_check && skip_move.is_none() {
         /*
         Reverse Futility Pruning:
@@ -475,6 +475,7 @@ pub fn search<Search: SearchType>(
         pos.make_move_fetch(make_move, |board| {
             shared_context.get_t_table().prefetch(&board)
         });
+        let (_, new_stm_threat) = pos.threats();
 
         let gives_check = !pos.board().checkers().is_empty();
         if gives_check {
@@ -503,6 +504,9 @@ pub fn search<Search: SearchType>(
             }
             if cut_node {
                 reduction += 1;
+            }
+            if new_stm_threat.len() > stm_threats.len() {
+                reduction -= 1;
             }
             reduction = reduction.min(depth as i16 - 2).max(0);
         }


### PR DESCRIPTION
Reduce LMR if the move results in more threats for the current side to move.

Passed STC:
```
Elo   | 5.95 +- 3.74 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 4.00]
Games | N: 10390 W: 2609 L: 2431 D: 5350
Penta | [84, 1177, 2522, 1301, 111]
```

Passed LTC:
```
Elo   | 4.27 +- 2.90 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.98 (-2.94, 2.94) [0.00, 4.00]
Games | N: 13672 W: 3196 L: 3028 D: 7448
Penta | [42, 1449, 3676, 1637, 32]
```