### PR TITLE
Remove double extension margin

### DIFF
--- a/src/bm/bm_search/search.rs
+++ b/src/bm/bm_search/search.rs
@@ -374,7 +374,7 @@ pub fn search<Search: SearchType>(
                 thread.ss[ply as usize].skip_move = None;
                 if s_score < s_beta {
                     extension = 1;
-                    if !Search::PV && multi_cut && s_score + 2 < s_beta {
+                    if !Search::PV && multi_cut && s_score < s_beta {
                         extension += 1;
                         if !is_capture && s_score + 180 < s_beta {
                             extension += 1;


### PR DESCRIPTION
Double extension margin was tuned down to 2 in the last SPSA tune. There is no point in having such a margin considering how low it is.

Passed LTC Simplification:
```
Elo   | 2.44 +- 2.97 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.94 (-2.94, 2.94) [-4.00, 0.00]
Games | N: 12798 W: 2954 L: 2864 D: 6980
Penta | [32, 1390, 3464, 1482, 31]
```