### PR TITLE
Double extend in PV nodes

### DIFF
--- a/src/bm/bm_search/search.rs
+++ b/src/bm/bm_search/search.rs
@@ -380,7 +380,7 @@ pub fn search<Search: SearchType>(
                             extension += 1;
                         }
                     }
-                    if Search::PV && multi_cut && s_score + 180 < s_beta {
+                    if Search::PV && multi_cut && s_score + 120 < s_beta {
                         extension += 1;
                     }
                     if !Search::PV && !multi_cut && eval + 100 <= alpha {

--- a/src/bm/bm_search/search.rs
+++ b/src/bm/bm_search/search.rs
@@ -380,6 +380,9 @@ pub fn search<Search: SearchType>(
                             extension += 1;
                         }
                     }
+                    if Search::PV && multi_cut && s_score + 180 < s_beta {
+                        extension += 1;
+                    }
                     if !Search::PV && !multi_cut && eval + 100 <= alpha {
                         extension += 1;
                     }


### PR DESCRIPTION
Double extend in PV nodes if candidate move is highly singular

Passed STC:
```
Elo   | 9.00 +- 4.66 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 3.12 (-2.94, 2.94) [0.00, 4.00]
Games | N: 6722 W: 1695 L: 1521 D: 3506
Penta | [55, 736, 1622, 876, 72]
```

Passed LTC:
```
Elo   | 7.50 +- 4.12 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 4.00]
Games | N: 6948 W: 1672 L: 1522 D: 3754
Penta | [21, 732, 1814, 890, 17]
```