### PR TITLE
Only update & save move when alpha is raised

### DIFF
--- a/src/bm/bm_search/search.rs
+++ b/src/bm/bm_search/search.rs
@@ -746,9 +746,9 @@ pub fn q_search(
         let score = search_score << Next;
         if highest_score.is_none() || score > highest_score.unwrap() {
             highest_score = Some(score);
-            best_move = Some(make_move);
         }
         if score > alpha {
+            best_move = Some(make_move);
             alpha = score;
             if score >= beta {
                 pos.unmake_move();
@@ -761,7 +761,7 @@ pub fn q_search(
     if thread.abort {
         return Evaluation::min();
     }
-    if let Some((best_move, highest_score)) = best_move.zip(highest_score) {
+    if let Some(highest_score) = highest_score {
         let entry_type = match () {
             _ if highest_score <= initial_alpha => Bounds::UpperBound,
             _ if highest_score >= beta => Bounds::LowerBound,
@@ -773,7 +773,7 @@ pub fn q_search(
             0,
             entry_type,
             highest_score,
-            Some(best_move),
+            best_move,
             raw_eval,
         );
     }

--- a/src/bm/bm_search/search.rs
+++ b/src/bm/bm_search/search.rs
@@ -158,7 +158,7 @@ pub fn search<Search: SearchType>(
         if entry.table_move.is_some() && best_move.is_none() {
             tt_entry = None;
         }
-        if !Search::PV && entry.depth >= depth && best_move.is_some() {
+        if !Search::PV && entry.depth >= depth {
             let score = entry.score;
             match entry.bounds {
                 Bounds::Exact => {
@@ -675,9 +675,11 @@ pub fn q_search(
         return pos.get_eval() + pos.aggression(thread.stm, thread.eval);
     }
 
+    let mut best_move = None;
     let initial_alpha = alpha;
     let tt_entry = shared_context.get_t_table().get(pos.board());
     if let Some(entry) = tt_entry {
+        best_move = entry.table_move;
         match entry.bounds {
             Bounds::LowerBound => {
                 if entry.score >= beta {
@@ -694,7 +696,6 @@ pub fn q_search(
     }
 
     let mut highest_score = None;
-    let mut best_move = None;
     let in_check = !pos.board().checkers().is_empty();
 
     let tt_eval = tt_entry.and_then(|entry| entry.eval);


### PR DESCRIPTION
We don't have a best move if we fail low so do not save the move if alpha is not raised.

Passed STC:
```
Elo   | 4.35 +- 3.07 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 4.00]
Games | N: 15402 W: 3910 L: 3717 D: 7775
Penta | [125, 1779, 3743, 1886, 168]
```

Passed LTC:
```
Elo   | 1.54 +- 1.19 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 4.00]
Games | N: 81516 W: 18848 L: 18487 D: 44181
Penta | [208, 9039, 21930, 9346, 235]
```