### PR TITLE
Update default network to proc1-4100M-e12

### DIFF
--- a/nn/default.bin
+++ b/nn/default.bin
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4a1fe6e404039ba01ee56db7c28c09471768e6acb5e2c2fbcd70c056456bbbb2
+oid sha256:f7e716b104e0ffcec6c7e5c9a8e7096350f31aaab129c6c1620e5b70907aecbd
 size 29369372


### PR DESCRIPTION
New neural network trained on 4100M positions

Passed STC:
```
Elo   | 5.97 +- 3.80 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 4.00]
Games | N: 10880 W: 2933 L: 2746 D: 5201
Penta | [132, 1220, 2553, 1399, 136]
```

Passed LTC:
```
Elo   | 5.70 +- 3.55 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 4.00]
Games | N: 9996 W: 2554 L: 2390 D: 5052
Penta | [45, 1083, 2593, 1217, 60]
```