### PR TITLE
QSearch LMP

### DIFF
--- a/src/bm/bm_search/search.rs
+++ b/src/bm/bm_search/search.rs
@@ -759,7 +759,7 @@ pub fn q_search(
         }
         pos.unmake_move();
         move_cnt += 1;
-        if move_cnt >= 3 {
+        if move_cnt >= 2 {
             break;
         }
     }

--- a/src/bm/bm_search/search.rs
+++ b/src/bm/bm_search/search.rs
@@ -713,6 +713,7 @@ pub fn q_search(
         }
     }
 
+    let mut move_cnt = 0;
     let mut move_gen = QSearchMoveGen::new();
     while let Some(make_move) = move_gen.next(pos, &thread.history) {
         /*
@@ -757,6 +758,10 @@ pub fn q_search(
             }
         }
         pos.unmake_move();
+        move_cnt += 1;
+        if move_cnt >= 3 {
+            break;
+        }
     }
 
     if thread.abort {


### PR DESCRIPTION
Search 2 moves per node at most in QS

Passed STC:
```
Elo   | 6.19 +- 3.76 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 3.03 (-2.94, 2.94) [0.00, 4.00]
Games | N: 9830 W: 2490 L: 2315 D: 5025
Penta | [68, 1105, 2404, 1260, 78]
```

Passed LTC:
```
Elo   | 5.33 +- 3.34 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 4.00]
Games | N: 10110 W: 2413 L: 2258 D: 5439
Penta | [21, 1070, 2717, 1227, 20]
```