### PR TITLE
Pawn Correction History

### DIFF
--- a/src/bm/bm_search/move_gen.rs
+++ b/src/bm/bm_search/move_gen.rs
@@ -196,10 +196,12 @@ impl OrderedMoveGen {
                             let followup_move_hist_2 = hist
                                 .get_followup_move_2(pos, hist_indices, mv)
                                 .unwrap_or_default();
+                            let threat_hist = hist.get_threat(pos, mv);
                             quiet_hist
                                 + counter_move_hist
                                 + followup_move_hist
                                 + followup_move_hist_2
+                                + threat_hist
                         }
                     };
                     self.quiets.push(ScoredMove::new(mv, score));

--- a/src/bm/bm_search/move_gen.rs
+++ b/src/bm/bm_search/move_gen.rs
@@ -196,12 +196,10 @@ impl OrderedMoveGen {
                             let followup_move_hist_2 = hist
                                 .get_followup_move_2(pos, hist_indices, mv)
                                 .unwrap_or_default();
-                            let pawn_hist = hist.get_pawn(pos, mv);
                             quiet_hist
                                 + counter_move_hist
                                 + followup_move_hist
                                 + followup_move_hist_2
-                                + pawn_hist
                         }
                     };
                     self.quiets.push(ScoredMove::new(mv, score));

--- a/src/bm/bm_search/move_gen.rs
+++ b/src/bm/bm_search/move_gen.rs
@@ -196,12 +196,12 @@ impl OrderedMoveGen {
                             let followup_move_hist_2 = hist
                                 .get_followup_move_2(pos, hist_indices, mv)
                                 .unwrap_or_default();
-                            let threat_hist = hist.get_threat(pos, mv);
+                            let pawn_hist = hist.get_pawn(pos, mv);
                             quiet_hist
                                 + counter_move_hist
                                 + followup_move_hist
                                 + followup_move_hist_2
-                                + threat_hist
+                                + pawn_hist
                         }
                     };
                     self.quiets.push(ScoredMove::new(mv, score));

--- a/src/bm/bm_search/search.rs
+++ b/src/bm/bm_search/search.rs
@@ -189,8 +189,7 @@ pub fn search<Search: SearchType>(
     };
     let aggr = pos.aggression(thread.stm, thread.eval);
     let corr = thread.history.get_correction(pos);
-    let no_corr_eval = raw_eval + aggr;
-    let eval = no_corr_eval + corr;
+    let eval = raw_eval + aggr + corr;
 
     thread.ss[ply as usize].aggr = aggr;
     thread.ss[ply as usize].eval = raw_eval;
@@ -648,7 +647,7 @@ pub fn search<Search: SearchType>(
         if !highest_score.is_mate() && !in_check && score_in_bounds {
             thread
                 .history
-                .update_corr_hist(pos, (highest_score - no_corr_eval).raw(), depth);
+                .update_corr_hist(pos, (highest_score - eval).raw(), depth);
         }
 
         shared_context.get_t_table().set(

--- a/src/bm/bm_search/search.rs
+++ b/src/bm/bm_search/search.rs
@@ -188,7 +188,8 @@ pub fn search<Search: SearchType>(
         None => tt_eval.unwrap_or_else(|| pos.get_eval()),
     };
     let aggr = pos.aggression(thread.stm, thread.eval);
-    let eval = raw_eval + aggr;
+    let corr = thread.history.get_correction(pos);
+    let eval = raw_eval + aggr + corr;
 
     thread.ss[ply as usize].aggr = aggr;
     thread.ss[ply as usize].eval = raw_eval;
@@ -638,6 +639,17 @@ pub fn search<Search: SearchType>(
             _ if highest_score >= beta => Bounds::LowerBound,
             _ => Bounds::Exact,
         };
+        let score_in_bounds = match entry_type {
+            Bounds::LowerBound => highest_score > eval,
+            Bounds::Exact => true,
+            Bounds::UpperBound => highest_score < eval,
+        };
+        if !highest_score.is_mate() && !in_check && score_in_bounds {
+            thread
+                .history
+                .update_corr_hist(pos, (highest_score - eval).raw());
+        }
+
         shared_context.get_t_table().set(
             pos.board(),
             depth,

--- a/src/bm/bm_search/search.rs
+++ b/src/bm/bm_search/search.rs
@@ -644,7 +644,11 @@ pub fn search<Search: SearchType>(
             Bounds::Exact => true,
             Bounds::UpperBound => highest_score < eval,
         };
-        if !highest_score.is_mate() && !in_check && score_in_bounds {
+        if !highest_score.is_mate()
+            && !in_check
+            && score_in_bounds
+            && best_move.map_or(true, |mv| !pos.is_capture(mv))
+        {
             thread
                 .history
                 .update_corr_hist(pos, (highest_score - eval).raw(), depth);

--- a/src/bm/bm_search/search.rs
+++ b/src/bm/bm_search/search.rs
@@ -189,7 +189,8 @@ pub fn search<Search: SearchType>(
     };
     let aggr = pos.aggression(thread.stm, thread.eval);
     let corr = thread.history.get_correction(pos);
-    let eval = raw_eval + aggr + corr;
+    let no_corr_eval = raw_eval + aggr;
+    let eval = no_corr_eval + corr;
 
     thread.ss[ply as usize].aggr = aggr;
     thread.ss[ply as usize].eval = raw_eval;
@@ -647,7 +648,7 @@ pub fn search<Search: SearchType>(
         if !highest_score.is_mate() && !in_check && score_in_bounds {
             thread
                 .history
-                .update_corr_hist(pos, (highest_score - eval).raw());
+                .update_corr_hist(pos, (highest_score - no_corr_eval).raw(), depth);
         }
 
         shared_context.get_t_table().set(

--- a/src/bm/bm_util/history.rs
+++ b/src/bm/bm_util/history.rs
@@ -7,9 +7,8 @@ use super::table_types::{new_butterfly_table, new_piece_to_table, Butterfly, Pie
 
 pub const MAX_HIST: i16 = 512;
 
-pub const CORR_HIST_SCALE: i32 = 1024;
 pub const CORR_HIST_GRAIN: i32 = 256;
-pub const MAX_CORRECT: i32 = 64;
+pub const MAX_CORRECT: i32 = 32;
 
 fn hist_stat(amt: i16) -> i16 {
     (amt * 13).min(MAX_HIST)

--- a/src/bm/bm_util/history.rs
+++ b/src/bm/bm_util/history.rs
@@ -54,6 +54,7 @@ impl HistoryIndices {
 #[derive(Debug, Clone)]
 pub struct History {
     quiet: Box<[[Butterfly<i16>; 2]; Color::NUM]>,
+    threat: Box<[[PieceTo<i16>; u16::MAX as usize + 1]; Color::NUM]>,
     capture: Box<[[Butterfly<i16>; 2]; Color::NUM]>,
     counter_move: Box<[PieceTo<PieceTo<i16>>; Color::NUM]>,
     followup_move: Box<[PieceTo<PieceTo<i16>>; Color::NUM]>,
@@ -63,6 +64,7 @@ impl History {
     pub fn new() -> Self {
         Self {
             quiet: Box::new([[new_butterfly_table(0); Color::NUM]; 2]),
+            threat: Box::new([[new_piece_to_table(0); u16::MAX as usize + 1]; Color::NUM]),
             capture: Box::new([[new_butterfly_table(0); Color::NUM]; 2]),
             counter_move: Box::new([new_piece_to_table(new_piece_to_table(0)); Color::NUM]),
             followup_move: Box::new([new_piece_to_table(new_piece_to_table(0)); Color::NUM]),
@@ -82,6 +84,21 @@ impl History {
         let (_, nstm_threats) = pos.threats();
         &mut self.quiet[stm as usize][nstm_threats.has(make_move.from) as usize]
             [make_move.from as usize][make_move.to as usize]
+    }
+
+    /// Returns threat indexed quiet history value for the given move
+    pub fn get_threat(&self, pos: &Position, make_move: Move) -> i16 {
+        let stm = pos.board().side_to_move();
+        let current_piece = pos.board().piece_on(make_move.from).unwrap();
+        self.threat[stm as usize][pos.threat_hash() as usize][current_piece as usize]
+            [make_move.to as usize]
+    }
+
+    fn get_threat_mut(&mut self, pos: &Position, make_move: Move) -> &mut i16 {
+        let stm = pos.board().side_to_move();
+        let current_piece = pos.board().piece_on(make_move.from).unwrap();
+        &mut self.threat[stm as usize][pos.threat_hash() as usize][current_piece as usize]
+            [make_move.to as usize]
     }
 
     /// Returns capture history value for the given move
@@ -244,6 +261,10 @@ impl History {
         bonus(self.get_quiet_mut(pos, make_move), amt);
         for &failed_move in fails {
             malus(self.get_quiet_mut(pos, failed_move), amt);
+        }
+        bonus(self.get_threat_mut(pos, make_move), amt);
+        for &failed_move in fails {
+            malus(self.get_threat_mut(pos, failed_move), amt);
         }
         if let Some(counter_move_hist) = self.get_counter_move_mut(pos, indices, make_move) {
             bonus(counter_move_hist, amt);

--- a/src/bm/bm_util/history.rs
+++ b/src/bm/bm_util/history.rs
@@ -285,10 +285,8 @@ impl History {
         let stm = pos.board().side_to_move();
         let hash = pos.pawn_hash();
         let prev_value = self.pawn_corr[stm as usize][hash as usize];
-        let weight = (depth * 16).min(128) as i32;
-        let new_value = (prev_value * (CORR_HIST_SCALE - weight)
-            + eval_diff as i32 * weight * CORR_HIST_GRAIN)
-            / CORR_HIST_SCALE;
+        let weight = (depth * 2).min(32) as i32;
+        let new_value = prev_value + eval_diff as i32 * weight;
         self.pawn_corr[stm as usize][hash as usize] = new_value.clamp(
             -MAX_CORRECT * CORR_HIST_GRAIN,
             MAX_CORRECT * CORR_HIST_GRAIN,

--- a/src/bm/bm_util/history.rs
+++ b/src/bm/bm_util/history.rs
@@ -285,7 +285,7 @@ impl History {
         let stm = pos.board().side_to_move();
         let hash = pos.pawn_hash();
         let prev_value = self.pawn_corr[stm as usize][hash as usize];
-        let weight = (depth * 4).min(64) as i32;
+        let weight = (depth * 8).min(128) as i32;
         let new_value = prev_value + eval_diff as i32 * weight;
         self.pawn_corr[stm as usize][hash as usize] = new_value.clamp(
             -MAX_CORRECT * CORR_HIST_GRAIN,

--- a/src/bm/bm_util/history.rs
+++ b/src/bm/bm_util/history.rs
@@ -9,6 +9,7 @@ pub const MAX_HIST: i16 = 512;
 
 pub const CORR_HIST_SCALE: i32 = 1024;
 pub const CORR_HIST_GRAIN: i32 = 256;
+pub const MAX_CORRECT: i32 = 64;
 
 fn hist_stat(amt: i16) -> i16 {
     (amt * 13).min(MAX_HIST)
@@ -285,9 +286,13 @@ impl History {
         let hash = pos.pawn_hash();
         let prev_value = self.pawn_corr[stm as usize][hash as usize];
         let weight = (depth * 16).min(128) as i32;
-        let new_value =
-            (prev_value * (CORR_HIST_SCALE - weight) + eval_diff as i32 * weight * CORR_HIST_GRAIN) / CORR_HIST_SCALE;
-        self.pawn_corr[stm as usize][hash as usize] = new_value;
+        let new_value = (prev_value * (CORR_HIST_SCALE - weight)
+            + eval_diff as i32 * weight * CORR_HIST_GRAIN)
+            / CORR_HIST_SCALE;
+        self.pawn_corr[stm as usize][hash as usize] = new_value.clamp(
+            -MAX_CORRECT * CORR_HIST_GRAIN,
+            MAX_CORRECT * CORR_HIST_GRAIN,
+        );
     }
 
     pub fn get_correction(&self, pos: &Position) -> i16 {

--- a/src/bm/bm_util/history.rs
+++ b/src/bm/bm_util/history.rs
@@ -286,13 +286,13 @@ impl History {
         let prev_value = self.pawn_corr[stm as usize][hash as usize];
         let weight = (depth * 16).min(128) as i32;
         let new_value =
-            (prev_value * (CORR_HIST_SCALE - weight) + eval_diff as i32 * weight) / CORR_HIST_SCALE;
+            (prev_value * (CORR_HIST_SCALE - weight) + eval_diff as i32 * weight * CORR_HIST_GRAIN) / CORR_HIST_SCALE;
         self.pawn_corr[stm as usize][hash as usize] = new_value;
     }
 
     pub fn get_correction(&self, pos: &Position) -> i16 {
         let stm = pos.board().side_to_move();
         let hash = pos.pawn_hash();
-        (self.pawn_corr[stm as usize][hash as usize] / 256) as i16
+        (self.pawn_corr[stm as usize][hash as usize] / CORR_HIST_GRAIN) as i16
     }
 }

--- a/src/bm/bm_util/history.rs
+++ b/src/bm/bm_util/history.rs
@@ -285,7 +285,7 @@ impl History {
         let stm = pos.board().side_to_move();
         let hash = pos.pawn_hash();
         let prev_value = self.pawn_corr[stm as usize][hash as usize];
-        let weight = (depth * 2).min(32) as i32;
+        let weight = (depth * 4).min(64) as i32;
         let new_value = prev_value + eval_diff as i32 * weight;
         self.pawn_corr[stm as usize][hash as usize] = new_value.clamp(
             -MAX_CORRECT * CORR_HIST_GRAIN,

--- a/src/bm/bm_util/mod.rs
+++ b/src/bm/bm_util/mod.rs
@@ -7,3 +7,4 @@ pub mod t_table;
 mod table_types;
 mod threats;
 pub mod window;
+pub mod zobrist;

--- a/src/bm/bm_util/position.rs
+++ b/src/bm/bm_util/position.rs
@@ -22,6 +22,8 @@ impl Position {
         let mut evaluator = Nnue::new();
         let (w_threats, b_threats) = threats(&board);
         evaluator.full_reset(&board, w_threats, b_threats);
+        let w_pawns = board.colored_pieces(Color::White, Piece::Pawn);
+        let b_pawns = board.colored_pieces(Color::Black, Piece::Pawn);
         Self {
             current: board,
             w_threats,
@@ -31,7 +33,7 @@ impl Position {
             moves: vec![],
             last_eval: 0,
             evaluator,
-            pawn_zobrist: Zobrist::new(w_threats, b_threats),
+            pawn_zobrist: Zobrist::new(w_pawns, b_pawns),
         }
     }
 
@@ -46,7 +48,10 @@ impl Position {
         self.boards.clear();
         self.threats.clear();
         self.moves.clear();
-        self.pawn_zobrist.clear(w_threats, b_threats);
+        self.pawn_zobrist.clear(
+            self.current.colored_pieces(Color::White, Piece::Pawn),
+            self.current.colored_pieces(Color::Black, Piece::Pawn),
+        );
         self.last_eval = 0;
     }
 
@@ -123,8 +128,8 @@ impl Position {
         self.current.play_unchecked(make_move);
         post_make(&self.current);
         (self.w_threats, self.b_threats) = threats(&self.current);
-        let w_pawns = old_board.colored_pieces(Color::White, Piece::Pawn);
-        let b_pawns = old_board.colored_pieces(Color::Black, Piece::Pawn);
+        let w_pawns = self.current.colored_pieces(Color::White, Piece::Pawn);
+        let b_pawns = self.current.colored_pieces(Color::Black, Piece::Pawn);
         self.pawn_zobrist
             .make_move(old_w_pawns ^ w_pawns, old_b_pawns ^ b_pawns);
         self.moves.push(Some(make_move));
@@ -197,7 +202,7 @@ impl Position {
         self.board().hash()
     }
 
-    pub fn threat_hash(&self) -> u16 {
+    pub fn pawn_hash(&self) -> u16 {
         self.pawn_zobrist.hash()
     }
 

--- a/src/bm/bm_util/position.rs
+++ b/src/bm/bm_util/position.rs
@@ -14,7 +14,7 @@ pub struct Position {
     moves: Vec<Option<Move>>,
     last_eval: usize,
     evaluator: Nnue,
-    threat_zobrist: Zobrist,
+    pawn_zobrist: Zobrist,
 }
 
 impl Position {
@@ -31,7 +31,7 @@ impl Position {
             moves: vec![],
             last_eval: 0,
             evaluator,
-            threat_zobrist: Zobrist::new(w_threats, b_threats),
+            pawn_zobrist: Zobrist::new(w_threats, b_threats),
         }
     }
 
@@ -46,7 +46,7 @@ impl Position {
         self.boards.clear();
         self.threats.clear();
         self.moves.clear();
-        self.threat_zobrist.clear(w_threats, b_threats);
+        self.pawn_zobrist.clear(w_threats, b_threats);
         self.last_eval = 0;
     }
 
@@ -102,7 +102,7 @@ impl Position {
         let Some(new_board) = self.board().null_move() else {
             return false;
         };
-        self.threat_zobrist.null_move();
+        self.pawn_zobrist.null_move();
         self.moves.push(None);
         self.boards.push(self.current.clone());
         self.threats.push((self.w_threats, self.b_threats));
@@ -117,13 +117,16 @@ impl Position {
         let old_w_threats = self.w_threats;
         let old_b_threats = self.b_threats;
 
+        let old_w_pawns = old_board.colored_pieces(Color::White, Piece::Pawn);
+        let old_b_pawns = old_board.colored_pieces(Color::Black, Piece::Pawn);
+
         self.current.play_unchecked(make_move);
         post_make(&self.current);
         (self.w_threats, self.b_threats) = threats(&self.current);
-        self.threat_zobrist.make_move(
-            self.w_threats ^ old_w_threats,
-            self.b_threats ^ old_b_threats,
-        );
+        let w_pawns = old_board.colored_pieces(Color::White, Piece::Pawn);
+        let b_pawns = old_board.colored_pieces(Color::Black, Piece::Pawn);
+        self.pawn_zobrist
+            .make_move(old_w_pawns ^ w_pawns, old_b_pawns ^ b_pawns);
         self.moves.push(Some(make_move));
         self.boards.push(old_board);
         self.threats.push((old_w_threats, old_b_threats));
@@ -180,7 +183,7 @@ impl Position {
     /// Takes back one (move)[Self::make_move]
     pub fn unmake_move(&mut self) {
         self.moves.pop().unwrap();
-        self.threat_zobrist.unmake_move();
+        self.pawn_zobrist.unmake_move();
         let current = self.boards.pop().unwrap();
         (self.w_threats, self.b_threats) = self.threats.pop().unwrap();
         self.current = current;
@@ -195,7 +198,7 @@ impl Position {
     }
 
     pub fn threat_hash(&self) -> u16 {
-        self.threat_zobrist.hash()
+        self.pawn_zobrist.hash()
     }
 
     /// Returns side to move relative threats

--- a/src/bm/bm_util/zobrist.rs
+++ b/src/bm/bm_util/zobrist.rs
@@ -22,11 +22,10 @@ pub struct Zobrist {
     stack: Vec<u16>,
     current: u16,
     hashes: [[u16; Square::NUM]; Color::NUM],
-    stm: u16,
 }
 
 impl Zobrist {
-    pub fn new() -> Self {
+    pub fn new(w: BitBoard, b: BitBoard) -> Self {
         let mut xor_shift = XorShift16::new();
         let mut hashes = [[0; Square::NUM]; Color::NUM];
         for color in &mut hashes {
@@ -34,40 +33,45 @@ impl Zobrist {
                 *square = xor_shift.next();
             }
         }
-        Self {
+        let mut zobrist = Self {
             stack: vec![],
             current: 0,
             hashes,
-            stm: xor_shift.next(),
-        }
+        };
+        zobrist.clear(w, b);
+        zobrist
     }
 
-	pub fn hash(&self) -> u16 {
-		self.current
-	}
+    pub fn hash(&self) -> u16 {
+        self.current
+    }
 
     pub fn null_move(&mut self) {
-        self.current ^= self.stm;
         self.stack.push(self.current)
     }
 
     pub fn make_move(&mut self, w_diff: BitBoard, b_diff: BitBoard) {
+        self.stack.push(self.current);
         for w in w_diff {
             self.current ^= self.hashes[0][w as usize];
         }
         for b in b_diff {
             self.current ^= self.hashes[1][b as usize];
         }
-        self.current ^= self.stm;
-        self.stack.push(self.current);
     }
 
     pub fn unmake_move(&mut self) {
         self.current = self.stack.pop().unwrap();
     }
 
-    pub fn clear(&mut self) {
+    pub fn clear(&mut self, w: BitBoard, b: BitBoard) {
         self.stack.clear();
         self.current = 0;
+        for w in w {
+            self.current ^= self.hashes[0][w as usize];
+        }
+        for b in b {
+            self.current ^= self.hashes[1][b as usize];
+        }
     }
 }

--- a/src/bm/bm_util/zobrist.rs
+++ b/src/bm/bm_util/zobrist.rs
@@ -1,0 +1,73 @@
+use cozy_chess::{BitBoard, Color, Square};
+
+struct XorShift16 {
+    state: u16,
+}
+
+impl XorShift16 {
+    fn new() -> Self {
+        Self { state: 1 }
+    }
+
+    fn next(&mut self) -> u16 {
+        self.state ^= self.state << 7;
+        self.state ^= self.state >> 9;
+        self.state ^= self.state << 8;
+        self.state
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Zobrist {
+    stack: Vec<u16>,
+    current: u16,
+    hashes: [[u16; Square::NUM]; Color::NUM],
+    stm: u16,
+}
+
+impl Zobrist {
+    pub fn new() -> Self {
+        let mut xor_shift = XorShift16::new();
+        let mut hashes = [[0; Square::NUM]; Color::NUM];
+        for color in &mut hashes {
+            for square in color {
+                *square = xor_shift.next();
+            }
+        }
+        Self {
+            stack: vec![],
+            current: 0,
+            hashes,
+            stm: xor_shift.next(),
+        }
+    }
+
+	pub fn hash(&self) -> u16 {
+		self.current
+	}
+
+    pub fn null_move(&mut self) {
+        self.current ^= self.stm;
+        self.stack.push(self.current)
+    }
+
+    pub fn make_move(&mut self, w_diff: BitBoard, b_diff: BitBoard) {
+        for w in w_diff {
+            self.current ^= self.hashes[0][w as usize];
+        }
+        for b in b_diff {
+            self.current ^= self.hashes[1][b as usize];
+        }
+        self.current ^= self.stm;
+        self.stack.push(self.current);
+    }
+
+    pub fn unmake_move(&mut self) {
+        self.current = self.stack.pop().unwrap();
+    }
+
+    pub fn clear(&mut self) {
+        self.stack.clear();
+        self.current = 0;
+    }
+}


### PR DESCRIPTION
Add SGD based pawn correction history.

Passed STC:
```
Elo   | 4.68 +- 3.22 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 4.00]
Games | N: 13952 W: 3524 L: 3336 D: 7092
Penta | [107, 1625, 3359, 1743, 142]
```

Passed LTC:
```
Elo   | 10.63 +- 4.99 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 4.00]
Games | N: 4608 W: 1179 L: 1038 D: 2391
Penta | [11, 454, 1238, 585, 16]
```