### PR TITLE
Qs corr standpat only

### DIFF
--- a/src/bm/bm_search/search.rs
+++ b/src/bm/bm_search/search.rs
@@ -687,8 +687,9 @@ pub fn q_search(
     thread.increment_nodes();
 
     thread.update_sel_depth(ply);
+    let correction = thread.history.get_correction(pos);
     if ply >= MAX_PLY {
-        return pos.get_eval() + pos.aggression(thread.stm, thread.eval);
+        return pos.get_eval() + pos.aggression(thread.stm, thread.eval) + correction;
     }
 
     let mut best_move = None;
@@ -721,11 +722,12 @@ pub fn q_search(
     If not in check, we have a stand pat score which is the static eval of the current position.
     This is done as captures aren't necessarily the best moves.
     */
-    if !in_check && stand_pat > alpha {
-        alpha = stand_pat;
-        highest_score = Some(stand_pat);
-        if stand_pat >= beta {
-            return stand_pat;
+    let corr_stand_pat = stand_pat + correction;
+    if !in_check && corr_stand_pat > alpha {
+        alpha = corr_stand_pat;
+        highest_score = Some(corr_stand_pat);
+        if corr_stand_pat >= beta {
+            return corr_stand_pat;
         }
     }
 

--- a/src/bm/bm_util/history.rs
+++ b/src/bm/bm_util/history.rs
@@ -280,15 +280,22 @@ impl History {
         }
     }
 
+    fn update_corr(val: &mut i32, eval_diff: i16, depth: u32) {
+        let weight = (depth * 8).min(128) as i32;
+        let new_value = *val + eval_diff as i32 * weight;
+        *val = new_value.clamp(
+            -MAX_CORRECT * CORR_HIST_GRAIN,
+            MAX_CORRECT * CORR_HIST_GRAIN,
+        );
+    }
+
     pub fn update_corr_hist(&mut self, pos: &Position, eval_diff: i16, depth: u32) {
         let stm = pos.board().side_to_move();
         let hash = pos.pawn_hash();
-        let prev_value = self.pawn_corr[stm as usize][hash as usize];
-        let weight = (depth * 8).min(128) as i32;
-        let new_value = prev_value + eval_diff as i32 * weight;
-        self.pawn_corr[stm as usize][hash as usize] = new_value.clamp(
-            -MAX_CORRECT * CORR_HIST_GRAIN,
-            MAX_CORRECT * CORR_HIST_GRAIN,
+        Self::update_corr(
+            &mut self.pawn_corr[stm as usize][hash as usize],
+            eval_diff,
+            depth,
         );
     }
 


### PR DESCRIPTION
Eval correction in QS, does not affect pruning other than standpat


Passed STC:
```
Elo   | 1.76 +- 1.37 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 4.00]
Games | N: 74168 W: 18376 L: 18001 D: 37791
Penta | [507, 8784, 18261, 8891, 641]
```

Passed LTC:
```
Elo   | 3.48 +- 2.54 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 4.00]
Games | N: 17870 W: 4331 L: 4152 D: 9387
Penta | [22, 2006, 4732, 2121, 54]
```