### PR TITLE
More logically sound history formula

### DIFF
--- a/src/bm/bm_search/search.rs
+++ b/src/bm/bm_search/search.rs
@@ -599,7 +599,7 @@ pub fn search<Search: SearchType>(
                 }
                 if score >= beta {
                     if !thread.abort {
-                        let amt = depth + (eval <= alpha) as u32 + (score - 50 > beta) as u32;
+                        let amt = depth + (eval <= initial_alpha) as u32 + (score - 50 > beta) as u32;
                         if !is_capture {
                             thread.killer_moves[ply as usize].push(make_move);
                         }


### PR DESCRIPTION
Passed LTC simplification, fix logic issue
```
Elo   | 2.34 +- 2.94 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.96 (-2.94, 2.94) [-4.00, 0.00]
Games | N: 13382 W: 3322 L: 3232 D: 6828
Penta | [32, 1491, 3556, 1579, 33]
```